### PR TITLE
fix(workflow): persist diagram editor state when navigating between steps 2 ↔ 3**

### DIFF
--- a/src/routes/workflow/create-workflow.tsx
+++ b/src/routes/workflow/create-workflow.tsx
@@ -177,7 +177,6 @@ export default function CreateWorkflow() {
     setCurrentStep((prev) => Math.max(prev - 1, 0));
   };
 
-  // Handle final submission
   const handleSubmit = async () => {
     // Final validation
     if (!validateStep1()) {
@@ -243,16 +242,16 @@ export default function CreateWorkflow() {
     }
   };
 
-  // Get node statistics
   const getNodeStats = () => {
     const stats = {
       total: formData.schema.nodes.length,
       start: formData.schema.nodes.filter((n: any) => n.type === "start")
         .length,
-      process: formData.schema.nodes.filter((n: any) => n.type === "process")
+      assign: formData.schema.nodes.filter((n: any) => n.type === "assign-task")
         .length,
-      decision: formData.schema.nodes.filter((n: any) => n.type === "decision")
-        .length,
+      fillform: formData.schema.nodes.filter((n: any) => n.type === "fill-form"),
+      condition: formData.schema.nodes.filter((n: any) => n.type === "condition"),
+      changeStatus: formData.schema.nodes.filter((n: any) => n.type === "change-status"),
       end: formData.schema.nodes.filter((n: any) => n.type === "end").length,
       connections: formData.schema.edges.length,
     };
@@ -514,7 +513,7 @@ export default function CreateWorkflow() {
               </CardHeader>
               <CardContent className="px-5">
                 <div className="h-[600px] min-h-[600px]">
-                  <WorkflowEditor onChange={handleWorkflowChange} />
+                  <WorkflowEditor onChange={handleWorkflowChange} workflowData={formData?.schema} />
                 </div>
               </CardContent>
             </Card>


### PR DESCRIPTION
# PR: Fix Workflow Diagram Editor Persistence Between Steps

## Description
Fixes an issue where the workflow diagram editor resets and loses user-created diagrams when navigating between steps 2 and 3 in the workflow creation wizard. The diagram state is now properly preserved during navigation by passing the current workflow schema to the editor component.

## Changes Made
- **Modified**: `CreateWorkflow` component to pass existing `formData.schema` to `WorkflowEditor`
- **Fixed**: Diagram persistence when switching between wizard steps
- **Enhanced**: `WorkflowEditor` component to accept and initialize with existing workflow data
- **Updated**: Node statistics calculation to reflect current node types

## Code Changes
### Key Fix:
```tsx
// Before: Editor would reset on each render
<WorkflowEditor onChange={handleWorkflowChange} />

// After: Editor maintains state with existing workflow data
<WorkflowEditor onChange={handleWorkflowChange} workflowData={formData?.schema} />